### PR TITLE
Enable UID and GID override for backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ volumes:
       device: /srv/pbs/lib
 ```
 
+### 6. Configure backup user UID & GID (optional)
+
+To change the case you wish to change what user and group id the container runs at then set the following
+
+Create a new file (or merge with existing): `docker-compose.override.yml`:
+
+```yaml
+version: '2.1'
+
+services:
+  pbs:
+    environment:
+      BGID: 1000
+      BUID: 1001
+```
+
 ## Install on bare-metal host
 
 Docker is convienient, but in some cases it might be simply better to install natively.

--- a/runit/proxmox-backup-api/run
+++ b/runit/proxmox-backup-api/run
@@ -6,7 +6,7 @@ fi
 
 # use the enivronment override for the user id and group id, otherwise use the default backup id of 34
 BUID=${BUID:-34}
-BGID=${BUID:-34}
+BGID=${BGID:-34}
 
 # set the group id for backup
 groupmod -o -g "$BGID" backup

--- a/runit/proxmox-backup-api/run
+++ b/runit/proxmox-backup-api/run
@@ -4,6 +4,15 @@ if [[ -n "$TZ" ]]; then
   echo "$TZ" > /etc/timezone
 fi
 
+# use the enivronment override for the user id and group id, otherwise use the default backup id of 34
+BUID=${BUID:-34}
+BGID=${BUID:-34}
+
+# set the group id for backup
+groupmod -o -g "$BGID" backup
+# set the user id for backup
+usermod -o -u "$BUID" backup
+
 # ensure that etc is owned by backup (due to configs)
 chown backup:backup /etc/proxmox-backup
 chmod 700 /etc/proxmox-backup


### PR DESCRIPTION
This PR enables the ability to set the UID and/or GID for the backup user/group within the container.

This PR should have no change to existing functionality, and it fixes an annoying issue im currently having on my synology NAS in which I cant read any of the files created by the container