### PR TITLE
Remove Kernel Version Regex Matching

### DIFF
--- a/versions/v3.1.2/server/proxmox-backup~fix-kernel-version.patch
+++ b/versions/v3.1.2/server/proxmox-backup~fix-kernel-version.patch
@@ -1,0 +1,13 @@
+diff --git a/www/panel/NodeInfo.js b/www/panel/NodeInfo.js
+index 72f97c7c..b8b2c4cc 100644
+--- a/www/panel/NodeInfo.js
++++ b/www/panel/NodeInfo.js
+@@ -151,7 +151,7 @@ Ext.define('PBS.NodeInfoPanel', {
+ 		    return data.kversion;
+ 		}
+ 		let kernel = data['current-kernel'];
+-		let buildDate = kernel.version.match(/\((.+)\)\s*$/)[1] ?? 'unknown';
++		let buildDate = kernel.version;
+ 		return `${kernel.sysname} ${kernel.release} (${buildDate})`;
+ 	    },
+ 	    value: '',


### PR DESCRIPTION
Since 3.1.2, kernel version is matched against a regex to extract only the date from the kernel version to display in the status box of the server.

Since there are no parenthesis in the kernel version reported, it breaks the rendering of the status panel of the dashboard.

This fixes #46.

![Capture d’écran du 2024-01-27 15-07-54](https://github.com/ayufan/pve-backup-server-dockerfiles/assets/8635747/c713be3f-bc1c-4fcb-84cc-7ebdfdcf72fc)
