### PR TITLE
Update permissions to 770

### DIFF
--- a/runit/proxmox-backup-api/run
+++ b/runit/proxmox-backup-api/run
@@ -6,15 +6,15 @@ fi
 
 # ensure that etc is owned by backup (due to configs)
 chown backup:backup /etc/proxmox-backup
-chmod 700 /etc/proxmox-backup
+chmod 770 /etc/proxmox-backup
 
 # ensure that lib is owned by backup (due to jobstates and rrdb)
 chown backup:backup /var/lib/proxmox-backup
-chmod 700 /var/lib/proxmox-backup
+chmod 770 /var/lib/proxmox-backup
 
 # ensure that logs are owned by backup
 chown backup:backup /var/log/proxmox-backup
-chmod 700 /var/log/proxmox-backup
+chmod 770 /var/log/proxmox-backup
 
 # recycle lock files
 rm /etc/proxmox-backup/.*.lck /etc/proxmox-backup/*.lock


### PR DESCRIPTION
Update permissions to 770 so users in the backup group have rwx access. Closes #49.