### PR TITLE
container: add journald socket compatibility for libsystemd callers

### DIFF
--- a/dockerfiles/runit/journal-compat/run
+++ b/dockerfiles/runit/journal-compat/run
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /run/systemd/journal
+
+# Provide the journald socket path expected by libsystemd callers.
+# In this container /dev/log already exists, but /run/systemd/journal/socket
+# does not, which causes proxmox-daily-update to fail with:
+#   Unable to open syslog: ... No such file or directory
+if [ ! -e /run/systemd/journal/socket ]; then
+    ln -s /dev/log /run/systemd/journal/socket
+fi
+
+# Keep the service alive so runit considers it running.
+exec tail -f /dev/null


### PR DESCRIPTION
## Summary

[Ref #110]

Some PBS binaries in the container use `libsystemd` logging and attempt to send to `/run/systemd/journal/socket`.

In this image `/dev/log` already exists, but `/run/systemd/journal/socket` does not, which causes `proxmox-daily-update` to emit:

```text
Unable to open syslog: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

`strace` shows the failing call is:

```text
sendto(..., {sa_family=AF_UNIX, sun_path="/run/systemd/journal/socket"}, ...) = -1 ENOENT
```

This change adds a small `runit` service that creates `/run/systemd/journal/socket` as a compatibility symlink to `/dev/log` at container startup.

## Why this approach

- avoids introducing `systemd` into the container
- avoids adding another syslog daemon when `/dev/log` is already present
- fixes the actual missing path used by `libsystemd` callers
- keeps the change small and container-specific

## Change

Add:

- `dockerfiles/runit/journal-compat/run`

which creates:

- `/run/systemd/journal/socket -> /dev/log`

before keeping the service alive under `runit`.
